### PR TITLE
fix: avoid blank pages by not nesting Routes.

### DIFF
--- a/src/shared/pages/App.tsx
+++ b/src/shared/pages/App.tsx
@@ -12,12 +12,8 @@ const AppRoutes = () => {
             <Route element={<NotFound />} path='*' />
             <Route element={<Home />} index />
             <Route element={<Docs />} path='docs' />
-            <Route path='app'>
-                <Route path='oauth'>
-                    <Route element={<OauthCreate />} path='create' />
-                </Route>
-                <Route element={<Manage />} path='manage/:id' />
-            </Route>
+            <Route element={<OauthCreate />} path='app/oauth/create' />
+            <Route element={<Manage />} path='app/manage/:id' />
         </Routes>
     );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified routing by flattening the nested routes under “app” into direct routes.
  - /app/oauth/create now directly maps to OauthCreate; /app/manage/:id directly maps to Manage.
  - Paths and behavior remain unchanged; existing links and bookmarks continue to work.
  - No changes to other pages (Home, Docs, NotFound) or visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->